### PR TITLE
Removes the need to pass a `project_id` to the `Client` and makes error responses from FCM accessible to the API consumer.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fcm-rs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Jalal Alizade"] 
 repository = "https://github.com/calalalizade/fcm-rs"
 description = "A Rust crate for easy interaction with Firebase Cloud Messaging API (V1)."

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add this crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-fcm_rust = "0.1.0"
+fcm_rust = "0.2.0"
 ```
 
 ## Usage
@@ -22,10 +22,9 @@ use fcm_rust::{ client::FcmClient, models::{ Message, Notification } };
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let service_account_path = "path/to/service_account";
-    let project_id = "your_project_id".to_string();
 
     // Create a new FCM client
-    let client = FcmClient::new(service_account_path, project_id).await?;
+    let client = FcmClient::new(service_account_path).await?;
 
     // Define the message with the target device token and notification details
     let message = Message {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,15 +1,13 @@
 //! Provides the `FcmClient` struct for interacting with the FCM API.
-use std::fmt::Display;
-
+use crate::error::FcmError;
+use crate::models::{FcmErrorResponse, FcmSendRequest, FcmSendResult, FcmSuccessResponse, Message};
 use reqwest::Client;
 use serde_json::json;
+use std::fmt::Display;
 use yup_oauth2::authenticator::Authenticator;
 use yup_oauth2::hyper::client::HttpConnector;
 use yup_oauth2::hyper_rustls::HttpsConnector;
 use yup_oauth2::{read_service_account_key, ServiceAccountAuthenticator};
-
-use crate::error::FcmError;
-use crate::models::{FcmErrorResponse, FcmSendRequest, FcmSendResult, FcmSuccessResponse, Message};
 
 /// Firebase Cloud Messaging (FCM) client.
 pub struct FcmClient {
@@ -38,7 +36,7 @@ impl FcmClient {
             Some(ref id) => id.clone(),
             None => {
                 return Err(FcmError::AuthError(
-                    "Service account missing project ID".to_string(),
+                    "Service account key JSON file missing project ID".to_string(),
                 ))
             }
         };
@@ -59,7 +57,7 @@ impl FcmClient {
     /// # Errors
     ///
     /// Returns an `FcmError` if there's an issue with the request, authentication,
-    /// JSON (de)serialization, or any other error during the sending process.
+    /// JSON (de)serialization, the response, or any other error during the sending process.
     pub async fn send(&self, message: Message) -> Result<FcmSuccessResponse, FcmError> {
         let url = format!(
             "https://fcm.googleapis.com/v1/projects/{}/messages:send",

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,12 +1,15 @@
 //! Provides the `FcmClient` struct for interacting with the FCM API.
+use std::fmt::Display;
+
 use reqwest::Client;
+use serde_json::json;
 use yup_oauth2::authenticator::Authenticator;
 use yup_oauth2::hyper::client::HttpConnector;
 use yup_oauth2::hyper_rustls::HttpsConnector;
-use yup_oauth2::{ ServiceAccountAuthenticator, read_service_account_key };
+use yup_oauth2::{read_service_account_key, ServiceAccountAuthenticator};
 
 use crate::error::FcmError;
-use crate::models::{ FcmSendRequest, FcmSendResponse, Message };
+use crate::models::{FcmErrorResponse, FcmSendRequest, FcmSendResult, FcmSuccessResponse, Message};
 
 /// Firebase Cloud Messaging (FCM) client.
 pub struct FcmClient {
@@ -24,16 +27,27 @@ impl FcmClient {
     /// # Arguments
     ///
     /// * `service_account_key_path` - Path to the service account key JSON file.
-    /// * `project_id` - Firebase project ID.
     ///
     /// # Errors
     ///
     /// Returns an `FcmError` if the service account key cannot be read,
     /// the authenticator cannot be built, or any other error occurs during initialization.
-    pub async fn new(service_account_key_path: &str, project_id: String) -> Result<Self, FcmError> {
+    pub async fn new(service_account_key_path: &str) -> Result<Self, FcmError> {
         let secret = read_service_account_key(service_account_key_path).await?;
+        let project_id = match secret.project_id {
+            Some(ref id) => id.clone(),
+            None => {
+                return Err(FcmError::AuthError(
+                    "Service account missing project ID".to_string(),
+                ))
+            }
+        };
         let auth = ServiceAccountAuthenticator::builder(secret).build().await?;
-        Ok(Self { auth, http_client: Client::new(), project_id })
+        Ok(Self {
+            auth,
+            http_client: Client::new(),
+            project_id,
+        })
     }
 
     /// Sends an FCM message.
@@ -46,30 +60,49 @@ impl FcmClient {
     ///
     /// Returns an `FcmError` if there's an issue with the request, authentication,
     /// JSON (de)serialization, or any other error during the sending process.
-    pub async fn send(&self, message: Message) -> Result<FcmSendResponse, FcmError> {
+    pub async fn send(&self, message: Message) -> Result<FcmSuccessResponse, FcmError> {
         let url = format!(
             "https://fcm.googleapis.com/v1/projects/{}/messages:send",
             self.project_id
         );
 
-        let token = self.auth.token(&["https://www.googleapis.com/auth/firebase.messaging"]).await?;
+        let token = self
+            .auth
+            .token(&["https://www.googleapis.com/auth/firebase.messaging"])
+            .await?;
 
-        let request = FcmSendRequest {
-            message,
-        };
+        let request = FcmSendRequest { message };
 
-        let response = self.http_client
+        let response = self
+            .http_client
             .post(url)
-            .header("Authorization", format!("Bearer {:?}", token.token().unwrap()))
+            .header(
+                "Authorization",
+                format!("Bearer {:?}", token.token().unwrap()),
+            )
             .json(&request) // Send the request object
-            .send().await?;
+            .send()
+            .await?;
 
-        // let response_text = response.text().await?; // Get raw response
-        // println!("Raw FCM response: {}", response_text); // Print for debugging
+        response
+            .json::<FcmSendResult>()
+            .await
+            .map_err(FcmError::from)?
+            .into()
+    }
+}
 
-        response.json::<FcmSendResponse>().await.map_err(FcmError::from)
+impl Into<Result<FcmSuccessResponse, FcmError>> for FcmSendResult {
+    fn into(self) -> Result<FcmSuccessResponse, FcmError> {
+        match self {
+            FcmSendResult::Success(success) => Ok(success),
+            FcmSendResult::Error(error) => Err(FcmError::ResponseError(error)),
+        }
+    }
+}
 
-        // let parsed_response: Result<FcmSendResponse, _> = serde_json::from_str(&response_text);
-        // parsed_response.map_err(FcmError::from)
+impl Display for FcmErrorResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", json!(&self))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 //! Error types for FCM operations.
-use thiserror::Error;
-
 use crate::models::FcmErrorResponse;
+use thiserror::Error;
 
 /// Represents errors that can occur while using the FCM client.
 #[derive(Error, Debug)]
@@ -26,7 +25,7 @@ pub enum FcmError {
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
 
-    // FCM responded with an error.
+    // An error in the response from FCM.
     #[error("Response error: {0}")]
     ResponseError(FcmErrorResponse),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,8 @@
 //! Error types for FCM operations.
 use thiserror::Error;
 
+use crate::models::FcmErrorResponse;
+
 /// Represents errors that can occur while using the FCM client.
 #[derive(Error, Debug)]
 pub enum FcmError {
@@ -23,4 +25,8 @@ pub enum FcmError {
     /// An error occurred during file I/O operations.
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
+
+    // FCM responded with an error.
+    #[error("Response error: {0}")]
+    ResponseError(FcmErrorResponse),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,6 @@
 //! * **Automatic Token Management:** Handles access token retrieval and refreshing seamlessly using `yup-oauth2`.
 //! * **Error Handling:** Includes comprehensive error handling for API requests, authentication, and deserialization.
 
+pub mod client;
 pub mod error; // Custom error types for FCM interactions
-pub mod models; // Data structures for FCM messages, responses, etc.
-pub mod client; // The FcmClient struct and methods to interact with FCM
+pub mod models; // Data structures for FCM messages, responses, etc. // The FcmClient struct and methods to interact with FCM

--- a/src/models.rs
+++ b/src/models.rs
@@ -32,31 +32,40 @@ pub struct FcmSendRequest {
     // Add other request parameters (e.g., validate_only: bool) if needed
 }
 
+/// Represents the result of a sent FCM message.
 #[derive(Deserialize)]
 #[serde(untagged)]
 pub enum FcmSendResult {
+    /// A successful response from FCM.
     Success(FcmSuccessResponse),
+    /// An error response from FCM.
     Error(FcmErrorResponse),
 }
 
-/// Represents a response from the FCM API after sending a message.
+/// Represents a successful response from the FCM API after sending a message.
 #[derive(Deserialize, Debug)]
 pub struct FcmSuccessResponse {
     /// Message ID if the message was successfully processed
     pub name: String,
 }
 
-/// Represents an error from the FCM API after sending a message.
+/// Represents an error response from the FCM API after sending a message.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct FcmErrorResponse {
-    /// Error if the message was unsuccessfully processed
+    /// Error if the message was unsuccessfully processed.
     pub error: ErrorResponse,
 }
 
+/// Contains the details of an error response from FCM.
+/// Visit the [FCM Documentation](https://firebase.google.com/docs/cloud-messaging/send-message#rest) for details on the possible errors the API can respond with.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ErrorResponse {
+    /// The error code.
     pub code: usize,
+    /// The error message.
     pub message: String,
+    /// The error status
     pub status: String,
+    /// Additional details about the error.
     pub details: Vec<Value>,
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,5 @@
 //! Data models for FCM messages, requests, and responses.
-use serde::{ Deserialize, Serialize };
+use serde::{Deserialize, Serialize};
 
 /// Represents an FCM message to be sent.
 #[derive(Serialize, Deserialize, Debug)]
@@ -31,9 +31,39 @@ pub struct FcmSendRequest {
     // Add other request parameters (e.g., validate_only: bool) if needed
 }
 
+#[derive(Deserialize)]
+#[serde(untagged)]
+pub enum FcmSendResult {
+    Success(FcmSuccessResponse),
+    Error(FcmErrorResponse),
+}
+
 /// Represents a response from the FCM API after sending a message.
 #[derive(Deserialize, Debug)]
-pub struct FcmSendResponse {
+pub struct FcmSuccessResponse {
     /// Message ID if the message was successfully processed
     pub name: String,
+}
+
+/// Represents an error from the FCM API after sending a message.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct FcmErrorResponse {
+    /// Error if the message was unsuccessfully processed
+    pub error: ErrorResponse,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ErrorResponse {
+    pub code: usize,
+    pub message: String,
+    pub status: String,
+    pub details: Vec<ErrorResponseDetail>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ErrorResponseDetail {
+    #[serde(rename = "type")]
+    pub ty: String,
+    #[serde(rename = "errorCode")]
+    pub error_code: String,
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,5 +1,6 @@
 //! Data models for FCM messages, requests, and responses.
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Represents an FCM message to be sent.
 #[derive(Serialize, Deserialize, Debug)]
@@ -57,13 +58,5 @@ pub struct ErrorResponse {
     pub code: usize,
     pub message: String,
     pub status: String,
-    pub details: Vec<ErrorResponseDetail>,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct ErrorResponseDetail {
-    #[serde(rename = "type")]
-    pub ty: String,
-    #[serde(rename = "errorCode")]
-    pub error_code: String,
+    pub details: Vec<Value>,
 }


### PR DESCRIPTION
The `Client` now pulls the `project_id` from the service account JSON file. If the `project_id` is not found in the file, `Client::new` returns an `FcmError::AuthError`.

Additionally, a new variant of `FcmError::ResponseError(FcmErrorResponse)` has been added to allow the API consumer access to error responses from FCM. Device tokens could be invalidated by the FCM Service at any time. The consumer of the API can look into these errors to find out what device tokens have been invalidated and therefore need to be removed from its local database.